### PR TITLE
User address

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,16 +2,29 @@
 
 class UsersController < ApplicationController
   def create
-    user = User.create(user_params)
+    service = UserRegistrationService.new(user_params, address_params).call
 
-    head(:internal_server_error) && return unless user.persisted?
+    head(:internal_server_error) && return unless service.success?
 
-    render(json: user, status: :created)
+    render(json: service.data, status: :created)
   end
 
   private
 
   def user_params
     params.permit(:fullname, :document, :birthdate, :gender, :password)
+  end
+
+  def address_params
+    params.require(:address).permit(
+      :country,
+      :state,
+      :city,
+      :district,
+      :street,
+      :number,
+      :complement,
+      :zip_code
+    )
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Address < ApplicationRecord
+  validates :country,
+            :state,
+            :city,
+            :district,
+            :street,
+            :number,
+            :complement,
+            :zip_code,
+            presence: true
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
   enum gender: { female: 0, male: 1 }
 
   validates :fullname, :document, :birthdate, :gender, :password, presence: true
+
+  has_one :address, dependent: :destroy
 end

--- a/app/services/user_registration_service.rb
+++ b/app/services/user_registration_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class UserRegistrationService
+  def initialize(user_attributes, address_attributes)
+    @user_attributes    = user_attributes
+    @address_attributes = address_attributes
+  end
+
+  def call
+    user = User.create(@user_attributes)
+
+    raise(ActiveRecord::RecordInvalid) unless user.persisted?
+
+    address = Address.create!(@address_attributes.merge(user_id: user.id))
+
+    raise(ActiveRecord::RecordInvalid) unless address.persisted?
+
+    OpenStruct.new(success?: true, data: user)
+  rescue ActiveRecord::RecordInvalid => e
+    OpenStruct.new(success?: false, error: e.message)
+  rescue StandardError => e
+    OpenStruct.new(success?: false, error: e.message)
+  end
+end

--- a/db/migrate/20200726213058_create_addresses.rb
+++ b/db/migrate/20200726213058_create_addresses.rb
@@ -1,0 +1,16 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.string :country
+      t.string :state
+      t.string :city
+      t.string :district
+      t.string :street
+      t.string :number
+      t.string :complement
+      t.string :zip_code
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200727005054_add_user_to_addresses_table.rb
+++ b/db/migrate/20200727005054_add_user_to_addresses_table.rb
@@ -1,0 +1,5 @@
+class AddUserToAddressesTable < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :addresses, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_26_203055) do
+ActiveRecord::Schema.define(version: 2020_07_27_005054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "country"
+    t.string "state"
+    t.string "city"
+    t.string "district"
+    t.string "street"
+    t.string "number"
+    t.string "complement"
+    t.string "zip_code"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "fullname"
@@ -26,4 +41,5 @@ ActiveRecord::Schema.define(version: 2020_07_26_203055) do
     t.string "password_digest"
   end
 
+  add_foreign_key "addresses", "users"
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :address do
+    country    { Faker::Address.country           }
+    state      { Faker::Address.state             }
+    city       { Faker::Address.city              }
+    district   { Faker::Address.community         }
+    street     { Faker::Address.street_name       }
+    number     { Faker::Address.building_number   }
+    complement { Faker::Address.secondary_address }
+    zip_code   { Faker::Address.zip_code          }
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require('rails_helper')
+
+RSpec.describe(Address, type: :model) do
+  context('when address country is blank') do
+    it('expects to be invalid') do
+      address = build(:address, country: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+
+  context('when address state is blank') do
+    it('expects to be invalid') do
+      address = build(:address, state: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+
+  context('when address city is blank') do
+    it('expects to be invalid') do
+      address = build(:address, city: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+
+  context('when address district is blank') do
+    it('expects to be invalid') do
+      address = build(:address, district: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+
+  context('when address street is blank') do
+    it('expects to be invalid') do
+      address = build(:address, street: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+
+  context('when address number is blank') do
+    it('expects to be invalid') do
+      address = build(:address, number: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+
+  context('when address complement is blank') do
+    it('expects to be invalid') do
+      address = build(:address, complement: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+
+  context('when address complement is blank') do
+    it('expects to be invalid') do
+      address = build(:address, complement: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+
+  context('when address zip code is blank') do
+    it('expects to be invalid') do
+      address = build(:address, zip_code: '')
+
+      expect(address).to(be_invalid)
+    end
+  end
+end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -4,19 +4,53 @@ require('rails_helper')
 
 RSpec.describe('Users', type: :request) do
   describe('POST /') do
-    let(:user) { attributes_for(:user) }
+    let(:user)    { attributes_for(:user) }
+    let(:address) { attributes_for(:address) }
 
-    it('returns http created') do
-      post('/users', params: user, as: :json)
-      expect(response).to(have_http_status(:created))
+    let(:invalid_user) do
+      # Sets all user attributes to empty string
+      user.each { |k, _v| user[k] = '' }
     end
 
-    it('returns http internal server error') do
-      # Sets all user attributes to empty string
-      invalid_user = user.each { |k, _v| user[k] = '' }
+    let(:invalid_address) do
+      # Sets all address attributes to empty string
+      address.each { |k, _v| address[k] = '' }
+    end
 
-      post('/users', params: invalid_user, as: :json)
-      expect(response).to(have_http_status(:internal_server_error))
+    context('when user and address are valid') do
+      it('returns http created') do
+        params = user.merge(address: address)
+
+        post('/users', params: params, as: :json)
+        expect(response).to(have_http_status(:created))
+      end
+    end
+
+    context('when user is invalid and address is valid') do
+      it('returns http internal server error') do
+        params = invalid_user.merge(address: address)
+
+        post('/users', params: params, as: :json)
+        expect(response).to(have_http_status(:internal_server_error))
+      end
+    end
+
+    context('when user is valid and address is invalid') do
+      it('returns http internal server error') do
+        params = user.merge(address: invalid_address)
+
+        post('/users', params: params, as: :json)
+        expect(response).to(have_http_status(:internal_server_error))
+      end
+    end
+
+    context('when user and address are invalid') do
+      it('returns http internal server error') do
+        params = invalid_user.merge(address: invalid_address)
+
+        post('/users', params: params, as: :json)
+        expect(response).to(have_http_status(:internal_server_error))
+      end
     end
   end
 end

--- a/spec/services/user_registration_service_spec.rb
+++ b/spec/services/user_registration_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require('rails_helper')
+
+RSpec.describe(UserRegistrationService) do
+  let(:user)    { attributes_for(:user)    }
+  let(:address) { attributes_for(:address) }
+
+  let(:invalid_user) do
+    # Sets all user attributes to empty string
+    user.each { |k, _v| user[k] = '' }
+  end
+
+  let(:invalid_address) do
+    # Sets all address attributes to empty string
+    address.each { |k, _v| address[k] = '' }
+  end
+
+  context('when user and address are valid') do
+    it('expects response to be success') do
+      service = described_class.new(user, address).call
+
+      expect(service).to(be_success)
+    end
+  end
+
+  context('when user is invalid and address is valid') do
+    it('expects response not to be success') do
+      service = described_class.new(invalid_user, address).call
+
+      expect(service).not_to(be_success)
+    end
+  end
+
+  context('when user is valid and address is invalid') do
+    it('expects response not to be success') do
+      service = described_class.new(user, invalid_address).call
+
+      expect(service).not_to(be_success)
+    end
+  end
+
+  context('when user and address are invalid') do
+    it('expects response not to be success') do
+      service = described_class.new(invalid_user, invalid_address).call
+
+      expect(service).not_to(be_success)
+    end
+  end
+end


### PR DESCRIPTION
In order to register an user, they must provide address information

(+) Adds `has_one/belongs_to` relationship between User and Address
(+) Adds `UserRegistrationService` to extract logic from `UsersController#create`
(+) Adds `UserRegistrationService` test
(=) Updates `UsersControllers#create` test to add address dependency