### PR TITLE
User account

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -2,8 +2,14 @@
 
 class Account < ApplicationRecord
   belongs_to :user
-  has_many :source_transactions, class_name: 'Transaction', foreign_key: 'source_account_id'
-  has_many :destination_transactions, class_name: 'Transaction', foreign_key: 'destination_account_id'
+
+  has_many :source_transactions,
+           class_name: 'Transaction',
+           foreign_key: 'source_account_id'
+
+  has_many :destination_transactions,
+           class_name: 'Transaction',
+           foreign_key: 'destination_account_id'
 
   before_create :create_account
 
@@ -14,7 +20,7 @@ class Account < ApplicationRecord
 
     self.number  = service.data[:number]
     self.agency  = service.data[:agency]
-    self.balance = service.data[:balance]
+    self.limit   = service.data[:limit]
     self.token   = service.data[:token]
   end
 end

--- a/app/services/user_account_creation_service.rb
+++ b/app/services/user_account_creation_service.rb
@@ -7,7 +7,7 @@ class UserAccountCreationService
       data: {
         number: account_number,
         agency: random_string,
-        balance: account_balance,
+        limit: account_limit,
         token: random_string
       }
     )
@@ -33,7 +33,7 @@ class UserAccountCreationService
     Array.new(4) { rand(1..9).to_s }.join
   end
 
-  def account_balance
+  def account_limit
     rand(1000..1800)
   end
 end

--- a/db/migrate/20200801141219_add_limit_to_accounts_table.rb
+++ b/db/migrate/20200801141219_add_limit_to_accounts_table.rb
@@ -1,0 +1,5 @@
+class AddLimitToAccountsTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :accounts, :limit, :decimal, precision: 8, scale: 2, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_000903) do
+ActiveRecord::Schema.define(version: 2020_08_01_141219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2020_07_28_000903) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
+    t.decimal "limit", precision: 8, scale: 2, default: "0.0"
     t.index ["user_id"], name: "index_accounts_on_user_id"
   end
 

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -4,7 +4,8 @@ FactoryBot.define do
   factory :account do
     number  { "#{Faker::Bank.account_number(digits: 4)}-1" }
     agency  { Faker::Number.number(digits: 4)              }
-    balance { Faker::Number.between(from: 1000, to: 1800)  }
+    balance { 0                                            }
+    limit   { Faker::Number.between(from: 1000, to: 1800)  }
     token   { Faker::Number.number(digits: 4)              }
     user    { association :user                            }
   end

--- a/spec/services/user_account_creation_service_spec.rb
+++ b/spec/services/user_account_creation_service_spec.rb
@@ -14,15 +14,14 @@ RSpec.describe(UserAccountCreationService) do
       expect(service.data[:number][0..3]).to(eq('1000'))
     end
 
-    it('expects account balance to be between 1000 and 1800') do
-      expect(service.data[:balance]).to(be_between(1000, 1800))
+    it('expects account limit to be between 1000 and 1800') do
+      expect(service.data[:limit]).to(be_between(1000, 1800))
     end
   end
 
   context('when there is already a registered account') do
     it('expects account number to be 1001-?') do
-      user = create(:user)
-      Account.create!(user_id: user.id)
+      create(:account)
 
       expect(service.data[:number][0..3]).to(eq('1001'))
     end


### PR DESCRIPTION
Starting balance should be zero while limit should be random, as of project requirements.

(+) Adds `limit` column to accounts table.
(=) Updates `UserAccountCreationService` to set random value to `limit` instead of `balance`.