### PR TITLE
Account limit update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ AllCops:
 
 Rails:
   Enabled: true
+
+Layout/LineLength:
+  Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ end
 
 group :test do
   gem 'database_cleaner-active_record'
+  gem 'timecop'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -226,6 +227,7 @@ DEPENDENCIES
   rubocop-rspec
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   tzinfo-data
 
 RUBY VERSION

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AccountsController < ApplicationController
+  before_action :set_account, only: %i[update]
+
+  def update
+    service = UpdateAccountLimitService.new(@account, account_params[:limit]).call
+
+    unless service.success?
+      render(json: { error: service.error }, status: :bad_request)
+      return
+    end
+
+    render(json: service.data, status: :ok)
+  end
+
+  private
+
+  def set_account
+    @account = Account.find_by(token: account_params[:token])
+  end
+
+  def account_params
+    params.permit(:token, :limit)
+  end
+end

--- a/app/services/update_account_limit_service.rb
+++ b/app/services/update_account_limit_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class UpdateAccountLimitService
+  def initialize(account, new_limit)
+    @account = account
+    @new_limit = new_limit
+  end
+
+  def call
+    raise(ActiveRecord::RecordInvalid, 'Limit cannot be less than 0.00') unless new_limit >= 0.00
+    raise(StandardError, 'Limit cannot be updated twice in less than 10 minutes') unless valid_interval?
+
+    account.update!(limit: new_limit, updated_at: Time.zone.now)
+
+    OpenStruct.new(success?: true, data: account)
+  rescue ActiveRecord::RecordInvalid => e
+    OpenStruct.new(success?: false, error: e.message)
+  rescue StandardError => e
+    OpenStruct.new(success?: false, error: e.message)
+  end
+
+  private
+
+  attr_reader :account, :new_limit
+
+  def valid_interval?
+    return true if account.updated_at.nil?
+
+    (Time.zone.now - account.updated_at) > update_interval
+  end
+
+  def update_interval
+    # Ten minutes
+    60 * 10
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   resource :users, only: %i[create], path: 'users'
+  resource :accounts, only: %i[update], path: 'accounts'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 require 'support/factory_bot'
 require 'database_cleaner/active_record'
+require 'timecop'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/accounts_request_spec.rb
+++ b/spec/requests/accounts_request_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require('rails_helper')
+
+RSpec.describe('Accounts', type: :request) do
+  describe('PUT /') do
+    let!(:account) do
+      Timecop.freeze(2020, 1, 1, 12, 0, 0) do
+        create(:account)
+      end
+    end
+
+    context('when account new limit is invalid') do
+      it('returns http bad request') do
+        params = { token: account.token, limit: -0.01 }
+
+        put('/accounts', params: params, as: :json)
+        expect(response).to(have_http_status(:bad_request))
+      end
+    end
+
+    context('when new limit has been set less than 10 minutes ago') do
+      let(:params) { { token: account.token, limit: 0.00 } }
+
+      before do
+        Timecop.freeze(2020, 1, 1, 12, 10, 1) do
+          put('/accounts', params: params, as: :json)
+        end
+      end
+
+      it('returns http bad request') do
+        Timecop.freeze(2020, 1, 1, 12, 19, 59) do
+          put('/accounts', params: params, as: :json)
+          expect(response).to(have_http_status(:bad_request))
+        end
+      end
+    end
+
+    context('when new limit is valid and respect the 10 minutes window') do
+      let(:params)         { { token: account.token, limit: 0.00 } }
+      let(:original_limit) { account.limit                         }
+
+      before do
+        Timecop.freeze(2020, 1, 1, 12, 10, 1) do
+          put('/accounts', params: params, as: :json)
+        end
+      end
+
+      it('returns http ok') do
+        Timecop.freeze(2020, 1, 1, 12, 20, 2) do
+          put('/accounts', params: params, as: :json)
+          expect(response).to(have_http_status(:ok))
+        end
+      end
+
+      it('expects limit to have been updated') do
+        expect { account.reload }.to(change(account, :limit).from(original_limit).to(0.00))
+      end
+    end
+  end
+end

--- a/spec/services/update_account_limit_service_spec.rb
+++ b/spec/services/update_account_limit_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require('rails_helper')
+
+RSpec.describe(UpdateAccountLimitService) do
+  let!(:account) { build(:account) }
+
+  context('when new limit is less than 0.00') do
+    let(:new_limit) { -0.01                                        }
+    let(:service)   { described_class.new(account, new_limit).call }
+
+    it('expects response not to be success') do
+      expect(service).not_to(be_success)
+    end
+  end
+
+  context('when new limit is equal to 0.00') do
+    let(:new_limit) { 0.00                                         }
+    let(:service)   { described_class.new(account, new_limit).call }
+
+    it('expects response to be success') do
+      expect(service).to(be_success)
+    end
+  end
+
+  context('when new limit is greater than 0.00') do
+    let(:new_limit) { 0.01                                         }
+    let(:service)   { described_class.new(account, new_limit).call }
+
+    it('expects response to be success') do
+      expect(service).to(be_success)
+    end
+  end
+
+  context('when limit has been updated less than 10 minutes ago') do
+    let(:new_limit) { 0.01                                         }
+    let(:service)   { described_class.new(account, new_limit).call }
+
+    before do
+      Timecop.freeze(2020, 1, 1, 12, 0, 0) do
+        described_class.new(account, new_limit).call
+      end
+    end
+
+    it('expects response not to be success') do
+      Timecop.freeze(2020, 1, 1, 12, 10, 0) do
+        expect(service).not_to(be_success)
+      end
+    end
+  end
+
+  context('when limit has been updated more than 10 minutes ago') do
+    let(:new_limit) { 0.01                                         }
+    let(:service)   { described_class.new(account, new_limit).call }
+
+    before do
+      Timecop.freeze(2020, 1, 1, 12, 0, 0) do
+        described_class.new(account, new_limit).call
+      end
+    end
+
+    it('expects response to be success') do
+      Timecop.freeze(2020, 1, 1, 12, 10, 1) do
+        expect(service).to(be_success)
+      end
+    end
+  end
+end


### PR DESCRIPTION
An user should be able to set it's account limit to any positive number providing they respect a 10 minutes window between updates.

(+) Adds `UpdateAccountLimitService` to handle limit update requests.
(+) Adds `AccountsController#update` action.
(+) Adds tests.
(+) Adds Timecop gem.